### PR TITLE
fix: correctly propagate streaming gRPC errors to Spark Connect clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ include = ["*"]  # package names should match these glob patterns (["*"] by defa
 
 [project]
 name = "spark-connect-proxy"
-version = "0.0.11"
+version = "0.0.12"
 description = "A reverse proxy server which allows secure connectivity to a Spark Connect server"
 readme = "README.md"
 authors = [{ name = "Philip Moore", email = "prmoore77@hotmail.com" }]

--- a/src/spark_connect_proxy/config.py
+++ b/src/spark_connect_proxy/config.py
@@ -13,3 +13,4 @@ DEFAULT_JWT_AUDIENCE = "spark-client"
 DEFAULT_JWT_ISSUER = "spark-connect-proxy"
 DEFAULT_JWT_SUBJECT = "spark-client"
 DEFAULT_JWT_LIFETIME: int = 3600 * 24  # 1 day
+DEFAULT_GRPC_MAX_MESSAGE_SIZE: int = 128 * 1024 * 1024 # 128mb spark connect default setting


### PR DESCRIPTION
This patch updates the SparkConnectProxyServicer to properly handle streaming RPCs (such as ExecutePlan) using `yield` instead of `return`.

Previously, some streaming methods incorrectly used `return`, which resulted in gRPC clients hanging indefinitely.

With this fix, gRPC errors from the SparkConnect stub are intercepted and forwarded to the client using `context.abort(e.code(), e.details())`, ensuring correct error propagation and better debuggability.